### PR TITLE
feat: auto init sheet with latest 12×2h candles and formatted timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ This repository contains sample Google Apps Script code to fetch cryptocurrency 
 
 The `coinbase_2h.gs` script provides two main functions:
 
-- `update2hPrices()` fetches the latest 2-hour candle close for BTC-USD, ETH-USD and SOL-USD from Coinbase Advanced Trade and appends it to the `Data` sheet in the active spreadsheet if the timestamp is new.
-- `initHistory(limit)` populates the `Data` sheet with the most recent 2-hour candles (100 by default).
+- `update2hPrices()` fetches the latest 2-hour candle close for BTC-USD, ETH-USD
+  and SOL-USD from Coinbase Advanced Trade and appends it to the `Data` sheet in
+  the active spreadsheet if the timestamp is new. When the sheet only contains
+  the header row it automatically invokes `initHistory()` first.
+- `initHistory()` fills the `Data` sheet with the most recent `HISTORY_ROWS`
+  two-hour candles (12 by default).
 
 The data is retrieved using the public Coinbase API endpoint:
 
@@ -17,6 +21,11 @@ See the official documentation for details: <https://docs.cloud.coinbase.com/exc
 
 The public API allows about 3 requests per second, so this script only queries a few products at low frequency.
 
-After deploying the script, create a trigger in Google Sheets to run `update2hPrices()` every 2 hours for continuous updates.
+After deploying the script you can run `update2hPrices()` manually once. If the
+sheet is still empty this will call `initHistory()` and backfill the latest
+history before appending the newest prices. Then create a time‑driven trigger in
+Google Sheets to execute `update2hPrices()` every 2 hours for continuous
+updates.
 
-At the end of the script a small sandbox executes `update2hPrices()` once and logs the result to verify the script runs without errors.
+At the end of the script a small sandbox executes `update2hPrices()` once and
+logs the result to verify the script runs without errors.


### PR DESCRIPTION
## Summary
- auto-fill sheet on first run with `initHistory`
- format timestamps for readability
- backfill history when sheet is empty
- document new behavior and trigger setup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684fc9847b3883319638d570af682bf4