### PR TITLE
Add summary row of hourly price changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ This repository contains sample Google Apps Script code to fetch cryptocurrency 
 
 The `coinbase_2h.gs` script exposes several utilities:
 
-- `update2hPrices()` rebuilds the `Data` sheet with the latest **13** two hour candles for BTC-USD, ETH-USD and SOL-USD.
+- `update2hPrices()` rebuilds the `Data` sheet with the latest **13** two hour candles for BTC-USD, ETH-USD and SOL-USD and automatically refreshes the summary row.
 - `fetchLatest2hCandles(product, limit)` builds recent 2h candles from 1h data.
 - `rolloverDailySheet()` copies the current `Data` sheet to a new sheet named by date and then refreshes `Data` for the new day.
 - `backfillHistory(start, end)` downloads historical two hour candles between two dates and stores them in a sheet named `History_<start>_to_<end>`.
-- `updateLatestChanges()` calculates the price changes of the newest row against the previous 2h, 4h, 12h and 24h rows and stores the result to the right of the table.
+- `updateLatestChanges()` calculates the change of the latest price against the previous
+  2h, 4h, 12h and 24h rows and writes a "Summary" row beneath the table.
 
 The data is retrieved using the public Coinbase API endpoint:
 
@@ -47,7 +48,6 @@ I2: =IFERROR((B2-B14)/B14, "")
 ```
 
 **表头必须 9 列，脚本自动补空列；若想手动添加公式请从 E2 开始向右写 Δ2h ~ Δ24h。**
-The `updateLatestChanges()` function appends its results on the last row
-starting from **column J**. The twelve columns hold BTC, ETH and SOL changes
-against the previous 2h, 4h, 12h and 24h rows in the format
-`delta (percent)`.
+The `updateLatestChanges()` function now writes a "Summary" row below the last
+data row. Columns starting from **J** show BTC, ETH and SOL changes against the
+previous 2h, 4h, 12h and 24h rows in the format `delta (percent)`.


### PR DESCRIPTION
## Summary
- compute latest BTC/ETH/SOL changes vs 2h/4h/12h/24h
- add `updateLatestChanges` logic to insert/update a `Summary` row
- refresh the summary after every `update2hPrices` call
- document summary row behaviour in README

## Testing
- `node -e "const fs=require('fs'); const src=fs.readFileSync('coinbase_2h.gs','utf8'); new Function(src);"`

------
https://chatgpt.com/codex/tasks/task_e_68522336cfec83319942f7f1bcc51921