### PR TITLE
Fix spot price logging function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ Use the Triggers panel to add two timed triggers:
 
 The `refreshLatestChanges()` function rebuilds this summary table and fills the
 cells with values such as `+97.2 (0.09%)`.
+
+## Simple spot price logger
+
+If you only need to append the latest spot prices to the `Data` sheet you can
+call the `appendLatestPrices()` function. It fetches the current BTC, ETH and
+SOL prices from Coinbase and writes them with a timestamp to the next empty row.
+
+To run it automatically open **Extensions → Apps Script → Triggers** and create
+a time‑driven trigger that runs `appendLatestPrices` at your desired interval
+(for example every 5 minutes).

--- a/crypto_trading.gs
+++ b/crypto_trading.gs
@@ -313,3 +313,34 @@ function onOpen() {
 
 /** Manual trigger to rebuild the ledger */
 function rebuildLedger() { syncLedgerWithData(); }
+
+/**
+ * Append the latest BTC, ETH and SOL spot prices to the "Data" sheet.
+ * Fetches prices from Coinbase and writes them with the current timestamp
+ * in yyyy-MM-dd HH:mm:ss format. Errors are written as "ERROR".
+ */
+function appendLatestPrices() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(DATA_SHEET_NAME);
+  if (!sheet) {
+    Logger.log('Sheet "' + DATA_SHEET_NAME + '" not found');
+    return;
+  }
+
+  const btc = fetchSpotPrice('BTC');
+  const eth = fetchSpotPrice('ETH');
+  const sol = fetchSpotPrice('SOL');
+
+  const timestamp = Utilities.formatDate(
+    new Date(),
+    Session.getScriptTimeZone(),
+    'yyyy-MM-dd HH:mm:ss'
+  );
+
+  sheet.appendRow([
+    timestamp,
+    btc !== null ? btc : 'ERROR',
+    eth !== null ? eth : 'ERROR',
+    sol !== null ? sol : 'ERROR'
+  ]);
+}


### PR DESCRIPTION
## Summary
- add `appendLatestPrices()` for simple spot price logging
- document new function and how to schedule with a trigger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685267f09d688331a8073c6e09874896